### PR TITLE
Add support for multiple builds in one manifest file

### DIFF
--- a/aws_ami_delete/__main__.py
+++ b/aws_ami_delete/__main__.py
@@ -30,7 +30,6 @@ def cli() -> None:
         for build in manifest['builds']:
             if build['packer_run_uuid'] == manifest['last_run_uuid']:
                 image_ids.extend(build['artifact_id'].split(','))
-                break
 
     for image_id in image_ids:
         if ':' in image_id:


### PR DESCRIPTION
Example manifest file:
```
{
  "builds": [
    {
      "name": "my_build1",
      "builder_type": "amazon-ebs",
      "build_time": 1657547368,
      "files": null,
      "artifact_id": "eu-west-1:ami-00000000000000000",
      "packer_run_uuid": "5833bd35-a8f1-5152-9c6e-2f7f68f88ca2",
      "custom_data": null
    },
    {
      "name": "my_build2",
      "builder_type": "amazon-ebssurrogate",
      "build_time": 1657547469,
      "files": null,
      "artifact_id": "eu-west-1:ami-11111111111111111",
      "packer_run_uuid": "5833bd35-a8f1-5152-9c6e-2f7f68f88ca2",
      "custom_data": null
    }
  ],
  "last_run_uuid": "5833bd35-a8f1-5152-9c6e-2f7f68f88ca2"
}
```

With such manifest file both AMIs should be deleted, but currently code breaks after the first one.